### PR TITLE
Clobber any existing tags in local with tags fetched from remote

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           set -euxo pipefail
           cd ${{ github.workspace }}
           git config gpg.ssh.allowedSignersFile ./config/allowed_release_signers
-          git fetch --tags
+          git fetch --tags -f
           git tag -v ${{ github.ref_name }}
       - name: "Build"
         run: |


### PR DESCRIPTION
When verifying tags in the release workflow, if a tag is fetched where its name already existed previously, it could result in an error while executing `git fetch --tags`.
To resolve this error, we need to force fetch tags from the remote repository with the `-f` flag.