### PR TITLE
GHA: minor typo fixes & use go1.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,12 +7,12 @@ on:
     branches:
       - main
 jobs:
-  build-squbi:
-    name: "Release Pivit"
+  build-pivit:
+    name: "Build Pivit"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.19.x]
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: "Install golang"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.19.x]
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: "Install golang"


### PR DESCRIPTION
Fix a couple of minor typos in the build workflow to improve accuracy.

Also use the newer `go1.19` for build checks.