### PR TITLE
Minor correction: cert import command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ by setting the `PIVIT_ORG`, `PIVIT_ORG_UNIT`, and `PIVIT_EMAIL` environment vari
 
 ## Import certificate to Yubikey
 ```
-pivit --import [file]
+pivit --import --cert-file [file]
 ```
 
 Imports a certificate from `file`.  

--- a/cmd/pivit/main.go
+++ b/cmd/pivit/main.go
@@ -82,6 +82,9 @@ func runCommand() error {
 		if *signFlag || *verifyFlag || *generateFlag || *resetFlag || *printFlag {
 			return errors.New("specify --help, --sign, --verify, --import, --generate, --reset or --print")
 		}
+		if *certFileOpt == "" {
+			return errors.New("specify --cert-file [file] for certificate import")
+		}
 		return commandImport(*certFileOpt)
 	}
 


### PR DESCRIPTION
A minor but likely not unimportant correction in the certificate import command example in README.md.

Also make the error message more straightforward when `--cert-file` option is missing for certificate import.