### PR TITLE
Simplify Makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,18 +26,13 @@ jobs:
           sudo apt install -y libpcsclite-dev
       - name: "Checkout code"
         uses: actions/checkout@v2
-      - name: "Build and run"
+      - name: "Build and test"
         run: |
           set -euxo pipefail
           cd ${{ github.workspace }}
-          make build
-          # Run simple test
-          gunzip -c build/pivit-*.gz > build/pivit
-          chmod +x build/pivit
-          ./build/pivit --help
+          make test
+
           if ${{ matrix.os == 'macos-latest' }}; then
             # Cross compile for darwin-arm64 and run simple test
-            make build GOARCH=arm64
-            gunzip -c build/pivit-darwin-arm64.gz > build/pivit
-            file build/pivit
+            make test GOARCH=arm64
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
-name: "Builds Sanity Checks"
+name: "Build Checks"
 on:
   push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,17 +34,17 @@ jobs:
           git config gpg.ssh.allowedSignersFile ./config/allowed_release_signers
           git fetch --tags -f
           git tag -v ${{ github.ref_name }}
-      - name: "Build"
+      - name: "Build release"
         run: |
           set -euxo pipefail
           cd ${{ github.workspace }}
-          make build
+          make release
           if ${{ matrix.os == 'macos-latest' }}; then
-            make build GOARCH=arm64
+            make release GOARCH=arm64
           fi
       - name: "Release versioned"
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
-          artifacts: "build/*"
+          artifacts: "pivit-*"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Simply Makefile and make it more useful for local development workflows:

* Move .PHONY declarations to above targets to align with them
* Improve reliability of env vars by getting them from go env.
* Align make targets with go command verbs.
* Create separate install and release make targets

GitHub Workflows: 
* Run build checks on all branches for a push