### PR TITLE
feat(import): optionally import the first cert in a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ and using those certificates to sign and verify data.
 
 It is fully compatible with how the `git` command line calls external programs to sign and verify commits and tags.
 
+
 ## Install
 
 ```shell
@@ -105,7 +106,7 @@ For example:
 ### Import certificate to Yubikey
 
 ```shell
-pivit --import [file]
+pivit [--first-pem] --import [file]
 ```
 
 Imports a certificate from `file`.  
@@ -113,7 +114,10 @@ The given filename is expected to contain a serialized x509 certificate encoded 
 
 This action prompts for the Yubikey PIN.
 
-### Print certificate information
+Add `--first-pem` to import the first PEM block from `file`, ignoring the rest.  This is helpful if using a CA that
+provides its issued certificates as a chain or bundle, with the end-entity certificate first (this is the convention).
+
+## Print certificate information
 
 ```shell
 pivit --print

--- a/cmd/pivit/import.go
+++ b/cmd/pivit/import.go
@@ -11,14 +11,14 @@ import (
 )
 
 // commandImport stores a certificate file in a yubikey PIV slot
-func commandImport(file string, slot string) error {
+func commandImport(file string, first bool, slot string) error {
 	certBytes, err := os.ReadFile(file)
 	if err != nil {
 		return errors.Wrap(err, "read certificate file")
 	}
 
 	block, rest := pem.Decode(certBytes)
-	if len(rest) > 0 || block == nil {
+	if (!first && len(rest) > 0) || block == nil {
 		return errors.New("failed to parse certificate")
 	}
 

--- a/cmd/pivit/main.go
+++ b/cmd/pivit/main.go
@@ -29,6 +29,7 @@ func runCommand() error {
 	detachSignFlag := getopt.BoolLong("detach-sign", 'b', "make a detached signature")
 	armorFlag := getopt.BoolLong("armor", 'a', "create ascii armored output")
 	statusFdOpt := getopt.IntLong("status-fd", 0, -1, "write special status strings to the file descriptor n.", "n")
+	firstOpt := getopt.BoolLong("first-pem", 0, "imports the first PEM block found when importing, ignoring the rest of the imported file")
 	tsaOpt := getopt.StringLong("timestamp-authority", 't', "", "URL of RFC3161 timestamp authority to use for timestamping", "url")
 	p256Flag := getopt.BoolLong("p256", 0, "use P-256 elliptic curve for key pair generation. If missing, P-384 is used")
 
@@ -92,7 +93,7 @@ func runCommand() error {
 		if *signFlag || *verifyFlag || *generateFlag || *resetFlag || *printFlag {
 			return errors.New("specify --help, --sign, --verify, --import, --generate, --reset or --print")
 		}
-		return commandImport(*importOpt, *slot)
+		return commandImport(*importOpt, *firstOpt, *slot)
 	}
 
 	if *printFlag {


### PR DESCRIPTION
Adds a flag (`--first-pem`) to relax the import command's behavior, importing the first PEM block found if `file` is a chain of certificates.