### PR TITLE
Use `check-signature-action`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,11 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Verify release tag"
-        run: |
-          set -euxo pipefail
-          cd ${{ github.workspace }}
-          git config gpg.ssh.allowedSignersFile ./config/allowed_release_signers
-          git fetch --tags -f
-          git tag -v ${{ github.ref_name }}
+        uses: cashapp/check-signature-action@v0.1.0
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          allowed-release-signers: yoavamit
       - name: "Build release"
         run: |
           set -euxo pipefail


### PR DESCRIPTION
Use the [`check-signature-action`](https://github.com/marketplace/actions/check-signature) step in the release workflow instead of a standalone bash script.