### PR TITLE
Add certificate start and end dates (self-signed only)

### DIFF
--- a/cmd/pivit/generate.go
+++ b/cmd/pivit/generate.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cashapp/pivit/cmd/pivit/utils"
 	"github.com/cashapp/pivit/cmd/pivit/yubikey"
@@ -169,6 +170,8 @@ func selfCertificate(serialNumber string, publicKey crypto.PublicKey, privateKey
 		KeyUsage:        x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:     extKeyUsage,
 		ExtraExtensions: []pkix.Extension{},
+		NotAfter:        time.Now().AddDate(1, 0, 0),
+		NotBefore:       time.Now(),
 	}
 
 	data, err := x509.CreateCertificate(rand.Reader, cert, cert, publicKey, privateKey)


### PR DESCRIPTION
This should resolve issue #33 

When creating a self-signed certificate, it defaults to setting the expiration date to the UNIX epoch time (1/1/1970).
This PR sets a default expiration time of 1 year to self-signed certificates to make the development processes easier.