### PR TITLE
Add key policy flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Reset the Yubikey's PIV applet and create a new PIN to access it.
 ### Generate a certificate
 
 ```shell
-pivit --generate [--p256] [--self-sign | --no-csr] [--assume-yes]
+pivit --generate [--p256] [--self-sign | --no-csr] [--assume-yes] [--pin-policy] [--touch-policy]
 ```
 
 Generate a new key pair in the Yubikey's card authentication slot.  
@@ -51,6 +51,12 @@ The `--assume-yes` flag can be used in combination with the `--self-sign` option
 Add the `--no-csr` flag to skip the certificate signing request being printed. In this case, you will not be prompted to touch your Yubikey.  
 This option is useful if you don't need the generated key to be a part of an existing PKI.  
 you can still verify the key's certificate using Yubico's certificate [here](https://developers.yubico.com/PIV/Introduction/PIV_attestation.html).
+
+The `--pin-policy` flag controls when to prompt for a PIN when accessing the generated key.  
+Set to one of `"never"`, `"once"`, or `"always"` (default is `"never"`).
+
+The `--touch-policy` flag controls when to prompt to physically touch the hardware when accessing the generated key.  
+Set to one of `"never"`, `"cached"`, or `"always"` (default is `"always"`).
 
 Output for the command will look like:
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The `--pin-policy` flag controls when to prompt for a PIN when accessing the gen
 Set to one of `"never"`, `"once"`, or `"always"` (default is `"never"`).
 
 The `--touch-policy` flag controls when to prompt to physically touch the hardware when accessing the generated key.  
-Set to one of `"never"`, `"cached"`, or `"always"` (default is `"always"`).
+Set to one of `"never"` or `"always"` (default is `"always"`).
 
 Output for the command will look like:
 
@@ -205,6 +205,11 @@ This command will cause the Yubikey to flash and will block until it is touched.
 
 When `git` is set up to sign commits and tags, it'll use the following hardcoded parameters `-sbau [user.signingkey] --status-fd=1`.  
 `user.signingkey` is taken from git's local/global configuration.
+
+> **Note**: Pivit was designed to support signing git commits.  
+> But, if the key being used was created using the `--pin-policy=always` it may not be fully supported.  
+> Right now, Pivit prompts for the PIN only via the command line. If you're using GUI based git clients like GitKraken 
+> or SourceTree you'll probably miss that prompt.  
 
 ### Verify signature
 

--- a/cmd/pivit/generate.go
+++ b/cmd/pivit/generate.go
@@ -21,7 +21,7 @@ import (
 )
 
 // commandGenerate generates a new key pair and certificate signing request
-func commandGenerate(slot string, isP256, selfSign, generateCsr, assumeYes bool) error {
+func commandGenerate(slot string, isP256, selfSign, generateCsr, assumeYes bool, pinPolicy piv.PINPolicy, touchPolicy piv.TouchPolicy) error {
 	yk, err := yubikey.Yubikey()
 	if err != nil {
 		return err
@@ -52,8 +52,8 @@ func commandGenerate(slot string, isP256, selfSign, generateCsr, assumeYes bool)
 	}
 	key := piv.Key{
 		Algorithm:   algorithm,
-		PINPolicy:   piv.PINPolicyNever,
-		TouchPolicy: piv.TouchPolicyAlways,
+		PINPolicy:   pinPolicy,
+		TouchPolicy: touchPolicy,
 	}
 
 	pivSlot := utils.GetSlot(slot)

--- a/cmd/pivit/main.go
+++ b/cmd/pivit/main.go
@@ -37,8 +37,8 @@ func runCommand() error {
 	selfSignFlag := getopt.BoolLong("self-sign", 0, "generate a self-signed certificate instead of a CSR")
 	noCsrFlag := getopt.BoolLong("no-csr", 0, "don't create and print a certificate signing request when generating a key pair")
 	assumeYesFlag := getopt.BoolLong("assume-yes", 0, "assume yes to any y/n prompts, for scripting")
-	pinPolicyFlag := getopt.EnumLong("pin-policy", 0, []string{"always", "once", "never"}, "never", "set the PIN policy of the generated key")
-	touchPolicyFlag := getopt.EnumLong("touch-policy", 0, []string{"always", "cached", "never"}, "always", "set the touch policy of the generated key")
+	pinPolicyFlag := getopt.EnumLong("pin-policy", 0, []string{"always", "once", "never"}, "never", "set the PIN policy of the generated key (never, once, or always)", "policy")
+	touchPolicyFlag := getopt.EnumLong("touch-policy", 0, []string{"always", "never"}, "always", "set the touch policy of the generated key (never or always)", "policy")
 
 	getopt.HelpColumn = 40
 	getopt.SetParameters("[files]")
@@ -102,21 +102,22 @@ func runCommand() error {
 			generateCsr = false
 		}
 		pinPolicy := piv.PINPolicyNever
-		if *pinPolicyFlag == "once" {
+		switch *pinPolicyFlag {
+		case "once":
 			pinPolicy = piv.PINPolicyOnce
-		} else if *pinPolicyFlag == "always" {
+		case "always":
 			pinPolicy = piv.PINPolicyAlways
-		} else if *pinPolicyFlag == "never" {
+		case "never":
 			pinPolicy = piv.PINPolicyNever
 		}
 		touchPolicy := piv.TouchPolicyAlways
-		if *touchPolicyFlag == "never" {
+		switch *touchPolicyFlag {
+		case "never":
 			touchPolicy = piv.TouchPolicyNever
-		} else if *touchPolicyFlag == "cached" {
-			touchPolicy = piv.TouchPolicyCached
-		} else if *touchPolicyFlag == "always" {
+		case "always":
 			touchPolicy = piv.TouchPolicyAlways
 		}
+
 		if pinPolicy == piv.PINPolicyNever && touchPolicy == piv.TouchPolicyNever {
 			return errors.New("can't set both PIN and touch policies to \"never\"")
 		}

--- a/cmd/pivit/main.go
+++ b/cmd/pivit/main.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/go-piv/piv-go/piv"
+
 	"github.com/pborman/getopt/v2"
 	"github.com/pkg/errors"
 )
@@ -35,6 +37,8 @@ func runCommand() error {
 	selfSignFlag := getopt.BoolLong("self-sign", 0, "generate a self-signed certificate instead of a CSR")
 	noCsrFlag := getopt.BoolLong("no-csr", 0, "don't create and print a certificate signing request when generating a key pair")
 	assumeYesFlag := getopt.BoolLong("assume-yes", 0, "assume yes to any y/n prompts, for scripting")
+	pinPolicyFlag := getopt.EnumLong("pin-policy", 0, []string{"always", "once", "never"}, "never", "set the PIN policy of the generated key")
+	touchPolicyFlag := getopt.EnumLong("touch-policy", 0, []string{"always", "cached", "never"}, "always", "set the touch policy of the generated key")
 
 	getopt.HelpColumn = 40
 	getopt.SetParameters("[files]")
@@ -97,7 +101,26 @@ func runCommand() error {
 		if *noCsrFlag {
 			generateCsr = false
 		}
-		return commandGenerate(*slot, isP256, *selfSignFlag, generateCsr, *assumeYesFlag)
+		pinPolicy := piv.PINPolicyNever
+		if *pinPolicyFlag == "once" {
+			pinPolicy = piv.PINPolicyOnce
+		} else if *pinPolicyFlag == "always" {
+			pinPolicy = piv.PINPolicyAlways
+		} else if *pinPolicyFlag == "never" {
+			pinPolicy = piv.PINPolicyNever
+		}
+		touchPolicy := piv.TouchPolicyAlways
+		if *touchPolicyFlag == "never" {
+			touchPolicy = piv.TouchPolicyNever
+		} else if *touchPolicyFlag == "cached" {
+			touchPolicy = piv.TouchPolicyCached
+		} else if *touchPolicyFlag == "always" {
+			touchPolicy = piv.TouchPolicyAlways
+		}
+		if pinPolicy == piv.PINPolicyNever && touchPolicy == piv.TouchPolicyNever {
+			return errors.New("can't set both PIN and touch policies to \"never\"")
+		}
+		return commandGenerate(*slot, isP256, *selfSignFlag, generateCsr, *assumeYesFlag, pinPolicy, touchPolicy)
 	}
 
 	if importFlag {

--- a/cmd/pivit/yubikey/yubikey_identity.go
+++ b/cmd/pivit/yubikey/yubikey_identity.go
@@ -66,21 +66,6 @@ func NewYubikeySigner(yk *piv.YubiKey, s piv.Slot) Signer {
 
 // Sign implements crypto.Signer
 func (y Signer) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
-	attestationCert, err := y.yk.AttestationCertificate()
-	if err != nil {
-		return nil, err
-	}
-
-	keyCert, err := y.yk.Certificate(y.s)
-	if err != nil {
-		return nil, err
-	}
-
-	attestation, err := piv.Verify(attestationCert, keyCert)
-	if err != nil {
-		return nil, err
-	}
-
 	auth := piv.KeyAuth{
 		PINPrompt: func() (string, error) {
 			pin, err := utils.GetPin()
@@ -94,10 +79,13 @@ func (y Signer) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]b
 	// yubikeys with version 4.3.0 and lower must have the PINPolicy parameter specified
 	// for newer versions, it's automatically inferred from the attestation certificate
 	version := y.yk.Version()
-	if version.Major < 4 {
-		auth.PINPolicy = attestation.PINPolicy
-	} else if version.Major == 4 && version.Minor < 3 {
-		auth.PINPolicy = attestation.PINPolicy
+	if version.Major < 4 || (version.Major == 4 && version.Minor < 3) {
+		pinPolicy, err := y.getPINPolicy()
+		if err != nil {
+			return nil, err
+		}
+
+		auth.PINPolicy = *pinPolicy
 	}
 
 	private, err := y.yk.PrivateKey(y.s, y.Public(), auth)
@@ -122,4 +110,22 @@ func (y Signer) Public() crypto.PublicKey {
 	}
 
 	return cert.PublicKey
+}
+
+func (y Signer) getPINPolicy() (*piv.PINPolicy, error) {
+	attestationCert, err := y.yk.AttestationCertificate()
+	if err != nil {
+		return nil, err
+	}
+
+	keyCert, err := y.yk.Certificate(y.s)
+	if err != nil {
+		return nil, err
+	}
+
+	attestation, err := piv.Verify(attestationCert, keyCert)
+	if err != nil {
+		return nil, err
+	}
+	return &attestation.PINPolicy, nil
 }

--- a/cmd/pivit/yubikey/yubikey_identity.go
+++ b/cmd/pivit/yubikey/yubikey_identity.go
@@ -87,14 +87,12 @@ func (y Signer) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]b
 			if err != nil {
 				return "", errors.Wrap(err, "get pin")
 			}
-			if attestation.TouchPolicy == piv.TouchPolicyAlways {
-				fmt.Println("Touch Yubikey now to sign data...")
-			}
 			return pin, nil
 		},
 	}
 
-	// Yubikeys with version 4.3.0 and lower must have the PIN policy caching strategy set
+	// yubikeys with version 4.3.0 and lower must have the PINPolicy parameter specified
+	// for newer versions, it's automatically inferred from the attestation certificate
 	version := y.yk.Version()
 	if version.Major < 4 {
 		auth.PINPolicy = attestation.PINPolicy


### PR DESCRIPTION
This PR should resolve issue #31 
It adds the ability to control the key access policy (PIN and touch) when generating a key.

It also adds (basic) support to prompt for a PIN when signing data if key access policy specifies a PIN is required for the specific key.

Note that PIN prompt during signing has limited support, and hasn't been tested when being invoked by a GUI application.