### PR TITLE
Added "cached" option when setting the touch policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This option is useful if you don't need the generated key to be a part of an exi
 you can still verify the key's certificate using Yubico's certificate [here](https://developers.yubico.com/PIV/Introduction/PIV_attestation.html).
 
 The `--pin-policy` flag controls when to prompt for a PIN when accessing the generated key.  
-Set to one of `never"`, `once`, or `always` (default is `never`).
+Set to one of `never`, `once`, or `always` (default is `never`).
 
 The `--touch-policy` flag controls when to prompt to physically touch the hardware when accessing the generated key.  
 Set to one of `never`, `cached`, or `always` (default is `always`).

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ This option is useful if you don't need the generated key to be a part of an exi
 you can still verify the key's certificate using Yubico's certificate [here](https://developers.yubico.com/PIV/Introduction/PIV_attestation.html).
 
 The `--pin-policy` flag controls when to prompt for a PIN when accessing the generated key.  
-Set to one of `"never"`, `"once"`, or `"always"` (default is `"never"`).
+Set to one of `never"`, `once`, or `always` (default is `never`).
 
 The `--touch-policy` flag controls when to prompt to physically touch the hardware when accessing the generated key.  
-Set to one of `"never"` or `"always"` (default is `"always"`).
+Set to one of `never`, `cached`, or `always` (default is `always`).
 
 Output for the command will look like:
 

--- a/cmd/pivit/generate.go
+++ b/cmd/pivit/generate.go
@@ -92,7 +92,7 @@ func commandGenerate(slot string, isP256, selfSign, generateCsr, assumeYes bool,
 		return errors.Wrap(err, "verify device certificate")
 	}
 	if selfSign {
-		if touchPolicy == piv.TouchPolicyAlways {
+		if touchPolicy != piv.TouchPolicyNever {
 			fmt.Println("Touch Yubikey now to sign your key...")
 		}
 
@@ -112,7 +112,7 @@ func commandGenerate(slot string, isP256, selfSign, generateCsr, assumeYes bool,
 			return errors.Wrap(err, "import self-signed certificate")
 		}
 	} else if generateCsr {
-		if touchPolicy == piv.TouchPolicyAlways {
+		if touchPolicy != piv.TouchPolicyNever {
 			fmt.Println("Touch Yubikey now to sign your CSR...")
 		}
 

--- a/cmd/pivit/main.go
+++ b/cmd/pivit/main.go
@@ -38,7 +38,7 @@ func runCommand() error {
 	noCsrFlag := getopt.BoolLong("no-csr", 0, "don't create and print a certificate signing request when generating a key pair")
 	assumeYesFlag := getopt.BoolLong("assume-yes", 0, "assume yes to any y/n prompts, for scripting")
 	pinPolicyFlag := getopt.EnumLong("pin-policy", 0, []string{"always", "once", "never"}, "never", "set the PIN policy of the generated key (never, once, or always)", "policy")
-	touchPolicyFlag := getopt.EnumLong("touch-policy", 0, []string{"always", "never"}, "always", "set the touch policy of the generated key (never or always)", "policy")
+	touchPolicyFlag := getopt.EnumLong("touch-policy", 0, []string{"always", "cached", "never"}, "always", "set the touch policy of the generated key (never, cached, or always)", "policy")
 
 	getopt.HelpColumn = 40
 	getopt.SetParameters("[files]")
@@ -114,12 +114,17 @@ func runCommand() error {
 		switch *touchPolicyFlag {
 		case "never":
 			touchPolicy = piv.TouchPolicyNever
+		case "cached":
+			touchPolicy = piv.TouchPolicyCached
 		case "always":
 			touchPolicy = piv.TouchPolicyAlways
 		}
 
 		if pinPolicy == piv.PINPolicyNever && touchPolicy == piv.TouchPolicyNever {
 			return errors.New("can't set both PIN and touch policies to \"never\"")
+		}
+		if pinPolicy == piv.PINPolicyNever && touchPolicy == piv.TouchPolicyCached {
+			return errors.New("can't set PIN policy to \"never\" and touch policy to \"cached\"")
 		}
 		return commandGenerate(*slot, isP256, *selfSignFlag, generateCsr, *assumeYesFlag, pinPolicy, touchPolicy)
 	}

--- a/cmd/pivit/main.go
+++ b/cmd/pivit/main.go
@@ -119,13 +119,10 @@ func runCommand() error {
 		case "always":
 			touchPolicy = piv.TouchPolicyAlways
 		}
-
 		if pinPolicy == piv.PINPolicyNever && touchPolicy == piv.TouchPolicyNever {
 			return errors.New("can't set both PIN and touch policies to \"never\"")
 		}
-		if pinPolicy == piv.PINPolicyNever && touchPolicy == piv.TouchPolicyCached {
-			return errors.New("can't set PIN policy to \"never\" and touch policy to \"cached\"")
-		}
+
 		return commandGenerate(*slot, isP256, *selfSignFlag, generateCsr, *assumeYesFlag, pinPolicy, touchPolicy)
 	}
 


### PR DESCRIPTION
This option is mostly supported by Yubico hardware with PIV applets, but could still be useful.

The meaning of setting this option is that once a connection to the PIV hardware is opened, it'll only prompt the user to touch the key 15 minutes after the first time it was touched since the connection was opened. This option is mostly helpful when you need to access the private key inside the PIV applet many times in a single connection.

This PR resolves issue #31 