### PR TITLE
Updated installation instructions to prefer using homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,24 @@ It is fully compatible with how the `git` command line calls external programs t
 
 ## Install
 
+### Brew
+
+```shell
+brew install pivit
+```
+
+### Go install
 ```shell
 go install github.com/cashapp/pivit/cmd/pivit@latest
 ```
 
+## Usage
 To set up git to use `pivit` to sign and verify signatures run the following commands:
 
 ```shell
 git config --(local|global) gpg.format x509
 git config --(local|global) gpg.x509.program pivit
 ```
-
-## Usage
 
 ### Reset and initialize Yubikey PIV
 


### PR DESCRIPTION
Now that pivit has its own formula in homebrew's core formula repository, it's better to install pivit that way.