### PR TITLE
Add Nix flakes support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,15 +37,3 @@ jobs:
             # test it
             make pivit GOARCH=arm64
           fi
-  build-nix:
-    name: "Nix Build"
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-      - name: Run `nix-build`
-        run: nix-build

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,32 @@
+name: "Nix Checks"
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  nix-build:
+    name: "Build with Nix"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Install Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Check Nix flake inputs
+        uses: DeterminateSystems/flake-checker-action@v4
+      - name: Check Nix flake
+        run: nix flake check
+      - name: Check `nix build`
+        run: nix build
+      - name: Check `nix develop`
+        run: nix develop --command true
+      - name: Check `nix-build`
+        run: nix-build nix/
+      - name: Check `nix-shell`
+        run: nix-shell --command true nix/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1704874635,
+        "narHash": "sha256-YWuCrtsty5vVZvu+7BchAxmcYzTMfolSPP5io8+WYCg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3dc440faeee9e889fe2d1b4d25ad0f430d449356",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-23.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+{
+  description = "Sign and verify data using x509 certificates on Yubikeys";
+
+  # Use latest stable nixpkgs repository
+  inputs.nixpkgs.url = "nixpkgs/nixos-23.11";
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"
+      ];
+
+      # Helper function to generate an attrset
+      # '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Nixpkgs instantiated for all supported system types.
+      nixpkgsFor = forAllSystems (
+        system: import nixpkgs { inherit system; }
+      );
+
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          # Use mkShell derivation from shell.nix
+          default = import ./nix/shell.nix { inherit pkgs; };
+        });
+
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          # Use buildGoModule derivation from default.nix
+          default = import ./nix/default.nix { inherit pkgs; };
+        });
+    };
+}

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,10 +1,57 @@
 # Building Pivit with Nix
 
-## Development Environment using `nix-shell`
+## Nix Flakes (Recommended)
 
-The [`shell.nix`](shell.nix) derivation can be used with `nix-shell`
-to enter into a development environment that includes all of the
-dependencies needed to build and test `pivit`:
+Nix Flakes are recommended for deterministic reproducibility (input
+revisions are pinned in flake.lock). The following nix commands can
+all be run from the top-level of this repository or by specifying the
+URL-like name of the github repo (`github:cashapp/pivit`).
+
+### Building with Nix
+
+```
+% nix build
+[...]
+% ./result/bin/pivit
+specify --help, --sign, --verify, --import, --generate, --reset or --print
+```
+
+### Shell with `pivit` in the path
+
+```
+% nix shell
+[...]
+% which pivit
+/nix/store/pqpl0r6vvwln590v9zlm63ym0jqc6s62-pivit-0.6.0/bin/pivit
+```
+
+### Development environment shell
+
+```
+% nix develop
+[...]
+(nix:nix-shell-env) $ make
+CGO_ENABLED=1 go build ./cmd/pivit
+[...]
+```
+
+### Install package to profile
+
+```
+% nix profile install
+[...]
+```
+
+### Nix (stable)
+
+For compatibility with the stable release of Nix without flakes
+support, Nix expressions are provided to use `nix-shell` and `nix-build`.
+
+### Development Environment using `nix-shell`
+
+[`shell.nix`](shell.nix) can be used with `nix-shell` to enter into a
+development environment that includes all of the dependencies needed
+to build and test `pivit`:
 
 ```
 % nix-shell
@@ -28,10 +75,10 @@ go: downloading github.com/chzyer/readline v1.5.1
 [nix-shell:~/src/github.com/cashapp/pivit]$
 ```
 
-## Building with `nix-build`
+### Building with `nix-build`
 
-The [`default.nix`](default.nix) derivation can be used to build pivit
-using `nix-build`:
+[`default.nix`](default.nix) can be used to build pivit with
+`nix-build`:
 
 ```
 % nix-build
@@ -67,6 +114,8 @@ directory:
 specify --help, --sign, --verify, --import, --generate, --reset or --print
 ```
 
+## Maintenance
+
 ### Updating `vendorHash`
 
 When the contents of `go.sum` change, the nix build will also fail due to a
@@ -81,3 +130,31 @@ error: 1 dependencies of derivation '/nix/store/cmvdxq4v7lwmcgpqpwjwnc3dngprqilj
 
 When this occurs, the current go modules derivation hash (shown for "got")
 needs to be set as `vendorHash` in [`default.nix`](default.nix).
+
+### Updating nixpkgs flake input
+
+A little while after a new stable NixOS/nixpkgs is released at the end
+of November and April each year, it is a good time to update the
+stable nixpkgs input URL in [`flake.nix`](../flake.nix):
+
+```
+   # Use a stable nixpkgs repository
+-  inputs.nixpkgs.url = "nixpkgs/nixos-23.04";
++  inputs.nixpkgs.url = "nixpkgs/nixos-23.11";
+
+   outputs = { self, nixpkgs }:
+```
+
+In addition, the pinned revisions of the flake inputs in
+[`flake.lock`](../flake.lock) should also be updated using
+`nix flake update`:
+
+```
+% nix flake update
+warning: Git tree '/home/ddz/src/github.com/cashapp/pivit' is dirty
+warning: updating lock file '/home/ddz/src/github.com/cashapp/pivit/flake.lock':
+• Updated input 'nixpkgs':
+    'github:NixOS/nixpkgs/6723fa4e4f1a30d42a633bef5eb01caeb281adc3' (2024-01-08)
+  → 'github:NixOS/nixpkgs/3dc440faeee9e889fe2d1b4d25ad0f430d449356' (2024-01-10)
+warning: Git tree '/Users/io/src/github.com/cashapp/pivit' is dirty
+```

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,5 +1,5 @@
-with import <nixpkgs> {};
-
+{ pkgs ? import <nixpkgs> {} }:
+with pkgs;
 let
   # A cgo dependency (go-piv) needs either pcsclite (Linux) or PCSC (macOS)
   pcsc = lib.optional stdenv.isLinux (lib.getDev pcsclite)
@@ -8,7 +8,7 @@ in buildGoModule rec {
   pname = "pivit";
   version = "0.6.0";
 
-  src = ./.;
+  src = ./..;
 
   # This needs to be updated whenever go.sum changes
   vendorHash = "sha256-S4Su9y10SjimxGAm/3k3tgritZ44ZB2N4CdwQEcGvQc=";

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,5 +1,5 @@
-with import <nixpkgs> {};
-
+{ pkgs ? import <nixpkgs> {} }:
+with pkgs;
 let
   # A cgo dependency (go-piv) needs either pcsclite (Linux) or PCSC (macOS)
   pcsc = lib.optional stdenv.isLinux (lib.getDev pcsclite)


### PR DESCRIPTION
This PR adds support for Nix flakes to `pivit` to enable reproducible builds and easy use on systems with Nix installed and flakes enabled. For example:
```
$ nix shell github:cashapp/pivit
[...]
% which pivit
/nix/store/pqpl0r6vvwln590v9zlm63ym0jqc6s62-pivit-0.6.0/bin/pivit
```

In addition:
* move stable nix expressions into `nix/`
* separate GHA nix checks to only run on PRs to `main` (they can be slow)