### PR TITLE
Update actions/setup-go and actions/checkout to the latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: "Install golang"
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
       - if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -24,7 +24,7 @@ jobs:
           sudo apt update
           sudo apt install -y libpcsclite-dev
       - name: "Checkout code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Build and test"
         run: |
           set -euxo pipefail

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
       - name: Install Magic Nix Cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: "Install golang"
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
       - if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -39,7 +39,7 @@ jobs:
         run: |
           brew install openssh
       - name: "Checkout code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Build release"
         run: |
           set -euxo pipefail


### PR DESCRIPTION
actions/setup-go@v2 and actions/checkout@v2 were using node 16 which is being deprecated.