### PR TITLE
Replace command params with structs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,16 +23,23 @@ GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 EXE = pivit-$(GOOS)-$(GOARCH)
 release: pivit
-	cp pivit $(EXE)
-	gzip -9 $(EXE)
+	(\
+	set -e ;\
+	cp pivit $(EXE) ;\
+	gzip -9 $(EXE) ;\
+	)
 
 #
 # test: run tests
 #
 .PHONY: test
 test: pivit
-	file pivit
-	./pivit --help
+	(\
+	set -e ;\
+	go test ./pkg/... ;\
+	file pivit ;\
+	./pivit --help ;\
+	)
 
 #
 # clean: remove locally built artifacts

--- a/cmd/pivit/main.go
+++ b/cmd/pivit/main.go
@@ -193,7 +193,7 @@ func runCommand() error {
 			return errors.New("can't set both PIN and touch policies to \"never\"")
 		}
 
-		opts := &pivit.GenerateOpts{
+		opts := &pivit.GenerateCertificateOpts{
 			Algorithm:   algorithm,
 			SelfSign:    *selfSignFlag,
 			GenerateCsr: generateCsr,

--- a/cmd/pivit/main.go
+++ b/cmd/pivit/main.go
@@ -106,6 +106,7 @@ func runCommand() error {
 		var err error
 		message = nil
 		if len(fileArgs) == 2 {
+			// verify detached signature
 			signature, err = os.Open(fileArgs[0])
 			if err != nil {
 				return errors.Wrap(err, "read signature file")
@@ -127,6 +128,7 @@ func runCommand() error {
 				}()
 			}
 		} else if len(fileArgs) == 1 {
+			// verify attached signature
 			signature, err = os.Open(fileArgs[0])
 			if err != nil {
 				return errors.Wrap(err, "read signature file")
@@ -135,6 +137,7 @@ func runCommand() error {
 				_ = signature.Close()
 			}()
 		} else if len(fileArgs) == 0 {
+			// verify attached signature from stdin
 			signature = os.Stdin
 		} else {
 			return errors.New(fmt.Sprintf("expected either 1, 2, or no file arguments but got: %v", fileArgs))

--- a/cmd/pivit/main.go
+++ b/cmd/pivit/main.go
@@ -77,7 +77,7 @@ func runCommand() error {
 				_ = message.Close()
 			}()
 		} else {
-			return errors.New(fmt.Sprintf("expected either 1 or no file arguments but got: %v", fileArgs))
+			return errors.New(fmt.Sprintf("expected 0 or 1 file arguments but got: %v", fileArgs))
 		}
 		opts := &pivit.SignOpts{
 			StatusFd:           *statusFdOpt,
@@ -140,7 +140,7 @@ func runCommand() error {
 			// verify attached signature from stdin
 			signature = os.Stdin
 		} else {
-			return errors.New(fmt.Sprintf("expected either 1, 2, or no file arguments but got: %v", fileArgs))
+			return errors.New(fmt.Sprintf("expected either 0, 1, or 2 file arguments but got: %v", fileArgs))
 		}
 
 		opts := &pivit.VerifyOpts{

--- a/cmd/pivit/main.go
+++ b/cmd/pivit/main.go
@@ -77,7 +77,7 @@ func runCommand() error {
 				_ = message.Close()
 			}()
 		} else {
-			return errors.New("unexpected file argument")
+			return errors.New(fmt.Sprintf("expected either 1 or no file arguments but got: %v", fileArgs))
 		}
 		opts := &pivit.SignOpts{
 			StatusFd:           *statusFdOpt,
@@ -137,7 +137,7 @@ func runCommand() error {
 		} else if len(fileArgs) == 0 {
 			signature = os.Stdin
 		} else {
-			return errors.New("unexpected file arguments")
+			return errors.New(fmt.Sprintf("expected either 1, 2, or no file arguments but got: %v", fileArgs))
 		}
 
 		opts := &pivit.VerifyOpts{

--- a/pkg/pivit/generate.go
+++ b/pkg/pivit/generate.go
@@ -20,16 +20,26 @@ import (
 	"github.com/pkg/errors"
 )
 
+// GenerateOpts specifies the possible parameters for the key type being generated, and certificate properties
 type GenerateOpts struct {
-	P256        bool
-	SelfSign    bool
+	// Algorithm elliptic curve algorithm type to use for the key pair
+	Algorithm piv.Algorithm
+	// SelfSign whether the certificate should be self-signed
+	SelfSign bool
+	// GenerateCsr whether to generate and print a certificate signing request
 	GenerateCsr bool
-	AssumeYes   bool
-	PINPolicy   piv.PINPolicy
+	// AssumeYes if true, do not prompt the user for anything and assume "yes" for all prompts - useful for scripting
+	AssumeYes bool
+	// PINPolicy specifies when to prompt for a PIN when accessing the private key.
+	// See piv.PINPolicy for more details and possible options
+	PINPolicy piv.PINPolicy
+	// TouchPolicy specifies when (or if) to touch the yubikey to access the private key
 	TouchPolicy piv.TouchPolicy
 }
 
-// GenerateCertificate generates a new key pair and certificate signing request
+// GenerateCertificate generates a new key pair and a certificate associated with it.
+// By default, the certificate is signed by Yubico.
+// See the GenerateOpts.GenerateCsr and GenerateOpts.SelfSign for other options.
 func GenerateCertificate(slot string, opts *GenerateOpts) error {
 	yk, err := yubikey.Yubikey()
 	if err != nil {
@@ -59,12 +69,8 @@ func GenerateCertificate(slot string, opts *GenerateOpts) error {
 		return errors.Wrap(err, "failed to use management key")
 	}
 
-	algorithm := piv.AlgorithmEC384
-	if opts.P256 {
-		algorithm = piv.AlgorithmEC256
-	}
 	key := piv.Key{
-		Algorithm:   algorithm,
+		Algorithm:   opts.Algorithm,
 		PINPolicy:   opts.PINPolicy,
 		TouchPolicy: opts.TouchPolicy,
 	}

--- a/pkg/pivit/generate.go
+++ b/pkg/pivit/generate.go
@@ -20,8 +20,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// GenerateOpts specifies the possible parameters for the key type being generated, and certificate properties
-type GenerateOpts struct {
+// GenerateCertificateOpts specifies the possible parameters for the key type being generated, and certificate properties
+type GenerateCertificateOpts struct {
 	// Algorithm elliptic curve algorithm type to use for the key pair
 	Algorithm piv.Algorithm
 	// SelfSign whether the certificate should be self-signed
@@ -39,8 +39,8 @@ type GenerateOpts struct {
 
 // GenerateCertificate generates a new key pair and a certificate associated with it.
 // By default, the certificate is signed by Yubico.
-// See the GenerateOpts.GenerateCsr and GenerateOpts.SelfSign for other options.
-func GenerateCertificate(slot string, opts *GenerateOpts) error {
+// See the GenerateCertificateOpts.GenerateCsr and GenerateCertificateOpts.SelfSign for other options.
+func GenerateCertificate(slot string, opts *GenerateCertificateOpts) error {
 	yk, err := yubikey.Yubikey()
 	if err != nil {
 		return err

--- a/pkg/pivit/import.go
+++ b/pkg/pivit/import.go
@@ -11,15 +11,20 @@ import (
 	"github.com/pkg/errors"
 )
 
-// CommandImport stores a certificate file in a yubikey PIV slot
-func CommandImport(file string, first bool, slot string) error {
-	certBytes, err := os.ReadFile(file)
+type ImportOpts struct {
+	Filename       string
+	StopAfterFirst bool
+}
+
+// ImportCertificate stores a certificate file in a yubikey PIV slot
+func ImportCertificate(slot string, opts *ImportOpts) error {
+	certBytes, err := os.ReadFile(opts.Filename)
 	if err != nil {
 		return errors.Wrap(err, "read certificate file")
 	}
 
 	block, rest := pem.Decode(certBytes)
-	if (!first && len(rest) > 0) || block == nil {
+	if (!opts.StopAfterFirst && len(rest) > 0) || block == nil {
 		return errors.New("failed to parse certificate")
 	}
 
@@ -45,10 +50,10 @@ func CommandImport(file string, first bool, slot string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to use management key")
 	}
-	return ImportCertificate(cert, yk, managementKey, slot)
+	return importCert(cert, yk, managementKey, slot)
 }
 
-func ImportCertificate(cert *x509.Certificate, yk *piv.YubiKey, managementKey *[24]byte, slot string) error {
+func importCert(cert *x509.Certificate, yk *piv.YubiKey, managementKey *[24]byte, slot string) error {
 	err := yk.SetCertificate(*managementKey, utils.GetSlot(slot), cert)
 	if err != nil {
 		return errors.Wrap(err, "set certificate")

--- a/pkg/pivit/import.go
+++ b/pkg/pivit/import.go
@@ -11,8 +11,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ImportOpts specifies the parameters required when importing a certificate to the yubikey
 type ImportOpts struct {
-	Filename       string
+	// Filename from which to read the certificate data from
+	Filename string
+	// StopAfterFirst if false and Filename contains more data after the first PEM block, then return an error
 	StopAfterFirst bool
 }
 

--- a/pkg/pivit/print.go
+++ b/pkg/pivit/print.go
@@ -9,8 +9,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// CommandPrint exports the certificate.
-func CommandPrint(slot string) error {
+// PrintCertificate exports the certificate.
+func PrintCertificate(slot string) error {
 	yk, err := yubikey.GetSigner(slot)
 	if err != nil {
 		return err

--- a/pkg/pivit/reset.go
+++ b/pkg/pivit/reset.go
@@ -11,8 +11,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// CommandReset resets the yubikey, sets a new pin, and sets a random PIN unblock key
-func CommandReset() error {
+// ResetYubikey resets the yubikey, sets a new pin, and sets a random PIN unblock key
+func ResetYubikey() error {
 	yk, err := yubikey.Yubikey()
 	if err != nil {
 		return err

--- a/pkg/pivit/sign.go
+++ b/pkg/pivit/sign.go
@@ -15,8 +15,17 @@ import (
 	"github.com/pkg/errors"
 )
 
-// CommandSign signs the filename given in fileArgs or the content from stdin if no filename was supplied
-func CommandSign(statusFd int, detach, armor bool, userId, timestampAuthority string, slot string, fileArgs []string) error {
+type SignOpts struct {
+	StatusFd           int
+	Detach             bool
+	Armor              bool
+	UserId             string
+	TimestampAuthority string
+	FileArgs           []string
+}
+
+// Sign signs the filename given in fileArgs or the content from stdin if no filename was supplied
+func Sign(slot string, opts *SignOpts) error {
 	yk, err := yubikey.GetSigner(slot)
 	if err != nil {
 		return errors.Wrap(err, "open PIV for signing")
@@ -28,16 +37,16 @@ func CommandSign(statusFd int, detach, armor bool, userId, timestampAuthority st
 		return errors.Wrap(err, "get identity certificate")
 	}
 
-	if err = certificateContainsUserId(cert, userId); err != nil {
+	if err = certificateContainsUserId(cert, opts.UserId); err != nil {
 		return errors.Wrap(err, "no suitable certificate found")
 	}
 
 	yubikeySigner := yubikey.NewYubikeySigner(yk, pivSlot)
-	status.SetupStatus(statusFd)
+	status.SetupStatus(opts.StatusFd)
 	var f io.ReadCloser
-	if len(fileArgs) == 1 {
-		if f, err = os.Open(fileArgs[0]); err != nil {
-			return errors.Wrapf(err, "open message file (%s)", fileArgs[0])
+	if len(opts.FileArgs) == 1 {
+		if f, err = os.Open(opts.FileArgs[0]); err != nil {
+			return errors.Wrapf(err, "open message file (%s)", opts.FileArgs[0])
 		}
 		defer func() {
 			_ = f.Close()
@@ -63,12 +72,12 @@ func CommandSign(statusFd int, detach, armor bool, userId, timestampAuthority st
 	// line before SIG_CREATED. BEGIN_SIGNING seems appropriate. GPG emits this,
 	// though GPGSM does not.
 	status.EmitBeginSigning()
-	if detach {
+	if opts.Detach {
 		sd.Detached()
 	}
 
-	if len(timestampAuthority) > 0 {
-		if err = sd.AddTimestamps(timestampAuthority); err != nil {
+	if len(opts.TimestampAuthority) > 0 {
+		if err = sd.AddTimestamps(opts.TimestampAuthority); err != nil {
 			return errors.Wrap(err, "add timestamp to signature")
 		}
 	}
@@ -83,8 +92,8 @@ func CommandSign(statusFd int, detach, armor bool, userId, timestampAuthority st
 		return errors.Wrap(err, "serialize signature")
 	}
 
-	status.EmitSigCreated(cert, detach)
-	if armor {
+	status.EmitSigCreated(cert, opts.Detach)
+	if opts.Armor {
 		err = pem.Encode(os.Stdout, &pem.Block{
 			Type:  "SIGNED MESSAGE",
 			Bytes: der,

--- a/pkg/pivit/sign.go
+++ b/pkg/pivit/sign.go
@@ -31,6 +31,8 @@ type SignOpts struct {
 	Message io.Reader
 }
 
+const signedMessagePemHeader = "SIGNED MESSAGE"
+
 // Sign creates a digital signature from the given data in SignOpts.Message
 func Sign(slot string, opts *SignOpts) error {
 	yk, err := yubikey.GetSigner(slot)
@@ -91,7 +93,7 @@ func Sign(slot string, opts *SignOpts) error {
 	status.EmitSigCreated(cert, opts.Detach)
 	if opts.Armor {
 		err = pem.Encode(os.Stdout, &pem.Block{
-			Type:  "SIGNED MESSAGE",
+			Type:  signedMessagePemHeader,
 			Bytes: der,
 		})
 	} else {

--- a/pkg/pivit/verify.go
+++ b/pkg/pivit/verify.go
@@ -21,7 +21,7 @@ type VerifyOpts struct {
 	// Signature to verify
 	Signature io.Reader
 	// Message associated with the signature.
-	// This option is only used when verifying detached signatures
+	// This option is only used when verifying a detached signature
 	Message io.Reader
 }
 
@@ -52,6 +52,10 @@ func VerifySignature(slot string, opts *VerifyOpts) error {
 			return errors.New("expected detached signature, but message wasn't provided")
 		}
 		return verifyDetached(sd, opts.Message, slot)
+	}
+
+	if opts.Message != nil {
+		return errors.New("expected to verify attached signature, but still got a message reader")
 	}
 	return verifyAttached(sd, slot)
 }

--- a/pkg/pivit/verify.go
+++ b/pkg/pivit/verify.go
@@ -37,6 +37,9 @@ func VerifySignature(slot string, opts *VerifyOpts) error {
 
 	var ber []byte
 	if blk, _ := pem.Decode(buf.Bytes()); blk != nil {
+		if blk.Type != signedMessagePemHeader {
+			return errors.New(fmt.Sprintf("unexpected PEM header: \"%s\"", blk.Type))
+		}
 		ber = blk.Bytes
 	} else {
 		ber = buf.Bytes()

--- a/pkg/pivit/verify.go
+++ b/pkg/pivit/verify.go
@@ -16,8 +16,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// CommandVerify verifies the data and signatures supplied in fileArgs
-func CommandVerify(fileArgs []string, slot string) error {
+// VerifySignature verifies the data and signatures supplied in fileArgs
+func VerifySignature(slot string, fileArgs []string) error {
 	status.EmitNewSign()
 
 	if len(fileArgs) < 2 {


### PR DESCRIPTION
Instead of receiving lots of parameters, make each exposed pivit operation function receive a structs with all the options relevant to that function.

This is another step towards making `pivit` a more usable library, instead of just a CLI tool.

The next step would be make each function also receive a pointer to a `piv.Yubikey` (which will also replace the `slot` parameter in certain functions).
Once that's done, we'll be able to more easily mock/fake the parameters given to each function and make everything more testable.