### PR TITLE
Override destination file in `make release` task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ EXE = pivit-$(GOOS)-$(GOARCH)
 release: pivit
 	(\
 	set -e ;\
-	cp pivit $(EXE) ;\
+	cp -f pivit $(EXE) ;\
 	gzip -9 $(EXE) ;\
 	)
 


### PR DESCRIPTION
This should resolve this error:
```
+ make release GOARCH=arm64
CGO_ENABLED=1 go build ./cmd/pivit
# github.com/cashapp/pivit/cmd/pivit
ld: warning: '/private/var/folders/zn/hj183dg15s713b47j2wlhwzw0000gn/T/go-link-2168477469/go.o' has malformed LC_DYSYMTAB, expected 106 undefined symbols to start at index 108[30](https://github.com/cashapp/pivit/actions/runs/10287345600/job/28470173311#step:6:31), found 125 undefined symbols starting at index 56
(\
	set -e ;\
	cp pivit pivit-darwin-arm64 ;\
	gzip -9 pivit-darwin-arm64 ;\
	)
gzip: pivit-darwin-arm64.gz already exists -- skipping
make: *** [release] Error 1
```
from the [v0.8.0 release job log](https://github.com/cashapp/pivit/actions/runs/10287345600/job/28470173311#step:6:38)