### PR TITLE
Override zipped binary when running `make release`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ release: pivit
 	(\
 	set -e ;\
 	cp -f pivit $(EXE) ;\
-	gzip -9 $(EXE) ;\
+	gzip -f -9 $(EXE) ;\
 	)
 
 #


### PR DESCRIPTION
Followup to PR #50 