### PR TITLE
build amd64 compatible binaries explicitly by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           set -euxo pipefail
           cd ${{ github.workspace }}
-          make release
+          make release GOARCH=amd64
           if ${{ matrix.os == 'macos-latest' }}; then
             make release GOARCH=arm64
           fi


### PR DESCRIPTION
if we're building for MacOSX, then also build for arm64