### PR TITLE
Move certificate parameters to a dedicated struct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test: pivit
 	set -e ;\
 	go test ./pkg/... ;\
 	file pivit ;\
-	./pivit --help ;\
+	./pivit --help 2> /dev/null ;\
 	)
 
 #

--- a/pkg/pivit/generate.go
+++ b/pkg/pivit/generate.go
@@ -10,7 +10,6 @@ import (
 	"math/big"
 	"net"
 	"net/url"
-	"slices"
 	"strconv"
 
 	"github.com/go-piv/piv-go/piv"
@@ -193,7 +192,7 @@ func selfCertificate(serialNumber string, publicKey crypto.PublicKey, privateKey
 		return nil, errors.Wrap(err, "create certificate random serial")
 	}
 
-	if !slices.Contains(params.CertificateEmailAddresses, params.SubjectEmailAddress) {
+	if !contains(params.CertificateEmailAddresses, params.SubjectEmailAddress) {
 		params.CertificateEmailAddresses = append(params.CertificateEmailAddresses, params.SubjectEmailAddress)
 	}
 
@@ -218,7 +217,7 @@ func selfCertificate(serialNumber string, publicKey crypto.PublicKey, privateKey
 }
 
 func certificateRequest(serialNumber string, privateKey crypto.PrivateKey, params CertificateParameters) ([]byte, error) {
-	if !slices.Contains(params.CertificateEmailAddresses, params.SubjectEmailAddress) {
+	if !contains(params.CertificateEmailAddresses, params.SubjectEmailAddress) {
 		params.CertificateEmailAddresses = append(params.CertificateEmailAddresses, params.SubjectEmailAddress)
 	}
 	subject := pkix.Name{
@@ -243,4 +242,13 @@ func certificateRequest(serialNumber string, privateKey crypto.PrivateKey, param
 	}
 
 	return csr, nil
+}
+
+func contains(slice []string, emailAddress string) bool {
+	for _, element := range slice {
+		if element == emailAddress {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/pivit/generate.go
+++ b/pkg/pivit/generate.go
@@ -42,6 +42,8 @@ type GenerateCertificateOpts struct {
 	Pin string
 }
 
+// CertificateParameters specifies the information encoded in the certificate
+// it's used to construct the certificate's subject, and targets (IP addresses, email, URIs, and DNS names)
 type CertificateParameters struct {
 	SubjectEmailAddress     string
 	SubjectOrganization     []string

--- a/pkg/pivit/generate.go
+++ b/pkg/pivit/generate.go
@@ -32,7 +32,8 @@ type GenerateCertificateOpts struct {
 	PINPolicy piv.PINPolicy
 	// TouchPolicy specifies when (or if) to touch the yubikey to access the private key
 	TouchPolicy piv.TouchPolicy
-	// CertificateParameters
+	// CertificateParameters contains the subject information and DNS names, URIs, IP addresses,
+	// and email addresses the generated certificate/CSR will be tied to
 	CertificateParameters CertificateParameters
 	// Slot to use for the private key
 	Slot piv.Slot


### PR DESCRIPTION
When generating a certificate or a certificate signing request, instead of getting the certificate subject information directly from environment variables, they'll be passed to the `GenerateCertificate` function in a dedicated struct. 
The environment variables will still be used by the pivit CLI executable to populate the `CertificateParameters` struct when calling `pivit --generate`.