### PR TITLE
chore: upgrade `piv-go` to v2

### DIFF
--- a/cmd/pivit/main.go
+++ b/cmd/pivit/main.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/cashapp/pivit/pkg/pivit"
-	"github.com/go-piv/piv-go/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 	"github.com/pborman/getopt/v2"
 	"github.com/pkg/errors"
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d
 	github.com/github/smimesign v0.2.0
-	github.com/go-piv/piv-go v1.11.0
+	github.com/go-piv/piv-go/v2 v2.1.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/pborman/getopt/v2 v2.1.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/github/smimesign v0.2.0 h1:Hho4YcX5N1I9XNqhq0fNx0Sts8MhLonHd+HRXVGNjvk=
 github.com/github/smimesign v0.2.0/go.mod h1:iZiiwNT4HbtGRVqCQu7uJPEZCuEE5sfSSttcnePkDl4=
-github.com/go-piv/piv-go v1.11.0 h1:5vAaCdRTFSIW4PeqMbnsDlUZ7odMYWnHBDGdmtU/Zhg=
-github.com/go-piv/piv-go v1.11.0/go.mod h1:NZ2zmjVkfFaL/CF8cVQ/pXdXtuj110zEKGdJM6fJZZM=
+github.com/go-piv/piv-go/v2 v2.1.0 h1:e2sqz91TY1q2LKlZGvfAuryV/2vpy7UeKs0Gwu/7AHs=
+github.com/go-piv/piv-go/v2 v2.1.0/go.mod h1:4l8gMOksz1w2USRwdHmhgiwVh+p+Rf8hfb/zKdZcmQM=
 github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/pborman/getopt v0.0.0-20180811024354-2b5b3bfb099b/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -11,7 +11,7 @@ in buildGoModule rec {
   src = ./..;
 
   # This needs to be updated whenever go.sum changes
-  vendorHash = "sha256-tgONzmRkJoFLA2PvXbum5BdPCtlyA4s6jNIjpmyUjvc=";
+  vendorHash = "sha256-Lr2TFHaTc85ZV+9BzLKejorCvqDdCRgQb5LZeMkWmHY=";
 
   buildInputs = pcsc;
 

--- a/pkg/pivit/fake_pivit.go
+++ b/pkg/pivit/fake_pivit.go
@@ -15,7 +15,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/go-piv/piv-go/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ed25519"
 )
@@ -25,7 +25,7 @@ type fakeYubikey struct {
 	privateKey      crypto.PrivateKey
 	attestationCert *x509.Certificate
 	serialNumber    string
-	managementKey   [24]byte
+	managementKey   []byte
 	pin             string
 	puk             string
 	slots           map[piv.Slot]*slotContent
@@ -211,7 +211,7 @@ func (f *fakeYubikey) Certificate(slot piv.Slot) (*x509.Certificate, error) {
 	return f.slots[slot].cert, nil
 }
 
-func (f *fakeYubikey) SetManagementKey(oldKey, newKey [24]byte) error {
+func (f *fakeYubikey) SetManagementKey(oldKey, newKey []byte) error {
 	if !bytes.Equal(f.managementKey[:], oldKey[:]) {
 		return errors.New("wrong management key")
 	}
@@ -226,7 +226,7 @@ func (f *fakeYubikey) Metadata(pin string) (*piv.Metadata, error) {
 	return f.metadata, nil
 }
 
-func (f *fakeYubikey) SetMetadata(managementKey [24]byte, metadata *piv.Metadata) error {
+func (f *fakeYubikey) SetMetadata(managementKey []byte, metadata *piv.Metadata) error {
 	if !bytes.Equal(f.managementKey[:], managementKey[:]) {
 		return errors.New("wrong management key")
 	}
@@ -258,7 +258,7 @@ func (f *fakeYubikey) SetPUK(oldPUK, newPUK string) error {
 	return nil
 }
 
-func (f *fakeYubikey) SetCertificate(managementKey [24]byte, slot piv.Slot, certificate *x509.Certificate) error {
+func (f *fakeYubikey) SetCertificate(managementKey []byte, slot piv.Slot, certificate *x509.Certificate) error {
 	if !bytes.Equal(f.managementKey[:], managementKey[:]) {
 		return errors.New("wrong management key")
 	}
@@ -292,7 +292,7 @@ func (f *fakeYubikey) SetCertificate(managementKey [24]byte, slot piv.Slot, cert
 	return nil
 }
 
-func (f *fakeYubikey) GenerateKey(managementKey [24]byte, slot piv.Slot, key piv.Key) (crypto.PublicKey, error) {
+func (f *fakeYubikey) GenerateKey(managementKey []byte, slot piv.Slot, key piv.Key) (crypto.PublicKey, error) {
 	if !bytes.Equal(f.managementKey[:], managementKey[:]) {
 		return nil, errors.New("wrong management key")
 	}

--- a/pkg/pivit/generate.go
+++ b/pkg/pivit/generate.go
@@ -12,7 +12,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/go-piv/piv-go/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pivit/generate_test.go
+++ b/pkg/pivit/generate_test.go
@@ -3,7 +3,7 @@ package pivit
 import (
 	"testing"
 
-	"github.com/go-piv/piv-go/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/pivit/import.go
+++ b/pkg/pivit/import.go
@@ -7,7 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 
-	"github.com/go-piv/piv-go/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pivit/import_test.go
+++ b/pkg/pivit/import_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-piv/piv-go/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/pivit/pivit.go
+++ b/pkg/pivit/pivit.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/go-piv/piv-go/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 	"github.com/pkg/errors"
 )
 
@@ -16,14 +16,14 @@ type Pivit interface {
 	Attest(slot piv.Slot) (*x509.Certificate, error)
 	PrivateKey(slot piv.Slot, publicKey crypto.PublicKey, auth piv.KeyAuth) (crypto.PrivateKey, error)
 	Certificate(slot piv.Slot) (*x509.Certificate, error)
-	SetManagementKey(oldKey, newKey [24]byte) error
+	SetManagementKey(oldKey, newKey []byte) error
 	Metadata(pin string) (*piv.Metadata, error)
-	SetMetadata(managementKey [24]byte, metadata *piv.Metadata) error
+	SetMetadata(managementKey []byte, metadata *piv.Metadata) error
 	Reset() error
 	SetPIN(oldPIN, newPIN string) error
 	SetPUK(oldPUK, newPUK string) error
-	SetCertificate(managementKey [24]byte, slot piv.Slot, certificate *x509.Certificate) error
-	GenerateKey(managementKey [24]byte, slot piv.Slot, key piv.Key) (crypto.PublicKey, error)
+	SetCertificate(managementKey []byte, slot piv.Slot, certificate *x509.Certificate) error
+	GenerateKey(managementKey []byte, slot piv.Slot, key piv.Key) (crypto.PublicKey, error)
 	Version() piv.Version
 }
 

--- a/pkg/pivit/print.go
+++ b/pkg/pivit/print.go
@@ -3,7 +3,7 @@ package pivit
 import (
 	"encoding/pem"
 
-	"github.com/go-piv/piv-go/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 
 	"github.com/pkg/errors"
 )

--- a/pkg/pivit/print_test.go
+++ b/pkg/pivit/print_test.go
@@ -3,7 +3,7 @@ package pivit
 import (
 	"testing"
 
-	"github.com/go-piv/piv-go/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/pivit/reset.go
+++ b/pkg/pivit/reset.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/go-piv/piv-go/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pivit/reset_test.go
+++ b/pkg/pivit/reset_test.go
@@ -3,7 +3,7 @@ package pivit
 import (
 	"testing"
 
-	"github.com/go-piv/piv-go/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/pivit/sign.go
+++ b/pkg/pivit/sign.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/go-piv/piv-go/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 
 	cms "github.com/github/smimesign/ietf-cms"
 	"github.com/pkg/errors"

--- a/pkg/pivit/sign_test.go
+++ b/pkg/pivit/sign_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/go-piv/piv-go/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/pivit/utils.go
+++ b/pkg/pivit/utils.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/go-piv/piv-go/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
 )
@@ -80,23 +80,23 @@ func GetSlot(slot string) piv.Slot {
 	}
 }
 
-// RandomManagementKey returns a *[24]byte slice filled with random byte values
-func RandomManagementKey() (*[24]byte, error) {
+// RandomManagementKey returns a *[]byte slice filled with random byte values
+func RandomManagementKey() (*[]byte, error) {
 	mk := make([]byte, 24)
 	if _, err := rand.Reader.Read(mk); err != nil {
 		return nil, err
 	}
-	return (*[24]byte)(mk), nil
+	return &mk, nil
 }
 
 // deriveManagementKey returns the first 24 bytes of the SHA256 checksum of the given pin
 // NOTE: this function has an error in it and SHOULD NOT BE USED.
 // It'll return the same checksum every time it's being called.
 // Its only use case should be in the GetOrSetManagementKey function for legacy reasons.
-func deriveManagementKey(pin string) *[24]byte {
+func deriveManagementKey(pin string) *[]byte {
 	hash := crypto.SHA256.New()
 	checksum := hash.Sum([]byte(pin))
-	var mk [24]byte
+	var mk []byte
 	copy(mk[:], checksum[:24])
 	return &mk
 }
@@ -107,8 +107,8 @@ func deriveManagementKey(pin string) *[24]byte {
 //  2. set it as the new management key
 //  3. store it in the PIV metadata section
 //  4. return the newly set management key
-func GetOrSetManagementKey(yk Pivit, pin string) (*[24]byte, error) {
-	var newManagementKey *[24]byte
+func GetOrSetManagementKey(yk Pivit, pin string) (*[]byte, error) {
+	var newManagementKey *[]byte
 	metadata, err := yk.Metadata(pin)
 	if err != nil {
 		return nil, err

--- a/pkg/pivit/utils_test.go
+++ b/pkg/pivit/utils_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/pem"
 	"testing"
 
-	"github.com/go-piv/piv-go/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -123,7 +123,7 @@ func TestRandomManagementKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Len(t, key1, 24)
+	assert.Len(t, *key1, 24)
 
 	key2, err := RandomManagementKey()
 	if err != nil {

--- a/pkg/pivit/verify.go
+++ b/pkg/pivit/verify.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/go-piv/piv-go/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 
 	"github.com/certifi/gocertifi"
 	cms "github.com/github/smimesign/ietf-cms"

--- a/pkg/pivit/verify_test.go
+++ b/pkg/pivit/verify_test.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/go-piv/piv-go/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Upgrades the `piv-go` dependency to `x2.1.0`, which handles the most recent Yubico firmware version.

Without this, we are seeing errors similar to:

```
smart card error 6a80: incorrect parameter in command data field
```