### PR TITLE
Support multiple YubiKeys via PIVIT_YK_SERIAL environment variable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ forking the repository and sending a pull request.
 
 When submitting code, please make every effort to follow existing conventions
 and style in order to keep the code as readable as possible. Please also make
-sure your code compiles by running `make build`.
+sure your code compiles by running `make`.
 
 Before your code can be accepted into the project you must also sign the
 [Individual Contributor License Agreement (CLA)][1].

--- a/README.md
+++ b/README.md
@@ -139,6 +139,20 @@ For example:
   pivit --print [-w slot]
   ```
 
+#### Specifying a Yubikey by serial number
+
+By default, `pivit` expects a single Yubikey to be attached. If a system has multiple card readers or Yubikeys, or
+to simply ensure pivit is talking to the intended Yubikey, specify the serial number via the `PIVIT_YK_SERIAL`
+environment variable.
+
+Example:
+
+```shell
+PIVIT_YK_SERIAL=13078292 pivit --print
+```
+
+This can be used with any command.
+
 ### Import certificate to Yubikey
 
 ```shell

--- a/cmd/pivit/main.go
+++ b/cmd/pivit/main.go
@@ -61,7 +61,7 @@ func runCommand() error {
 		return nil
 	}
 
-	yk, err := pivit.YubikeyHandle()
+	yk, err := pivit.YubikeyHandleWithSerial(os.Getenv("PIVIT_YK_SERIAL"))
 	if err != nil {
 		return errors.Wrap(err, "failed to open yubikey")
 	}

--- a/pkg/pivit/pivit.go
+++ b/pkg/pivit/pivit.go
@@ -50,7 +50,6 @@ func YubikeyHandleWithSerial(serial string) (*piv.YubiKey, error) {
 		return nil, errors.New("no smart card found")
 	}
 
-	// If no serial specified, only succeed if exactly one card is present
 	if serial == "" {
 		if len(cards) > 1 {
 			return nil, errors.New("multiple smart cards found but no serial specified")
@@ -59,20 +58,17 @@ func YubikeyHandleWithSerial(serial string) (*piv.YubiKey, error) {
 		return yk, err
 	}
 
-	// Parse the expected serial number
 	expectedSerial, err := strconv.ParseUint(serial, 10, 32)
 	if err != nil {
 		return nil, fmt.Errorf("invalid serial number format: %v", err)
 	}
 
-	// Serial specified - try to find matching card
 	for _, card := range cards {
 		yk, err := piv.Open(card)
 		if err != nil {
 			continue
 		}
 
-		// Get serial number
 		cardSerial, err := yk.Serial()
 		if err != nil {
 			yk.Close()


### PR DESCRIPTION
### Overview
This change allows users to use `pivit` while multiple YubiKeys are attached, or just want specificity when interacting with a YubiKey. This also tweaks the contributing guide make command.

Errors when:
- no cards are found
- multiple cards are found and the serial is not specified
- one or more cards are found and the serial does not match any

Successfully returns a card when:
- only one card is found and the serial is not specified
- one or more cards are found and the serial matches

Note that this also applies if there are other potential PIV sources attached, such as a smart card reader.

### Changes
* Create a new `YubikeyHandleWithSerial()` function.
* Make `YubikeyHandle()` call the new function with backward-compatible behavior.
* Update `runCommand()` to read the serial from the environment and use the new function.
* Tweak the contributing guide.

### Testing
Behavior when one YubiKey is attached:
```
~ $ pivit
specify --help, --sign, --verify, --import, --generate, --reset or --print
~ $ PIVIT_YK_SERIAL= pivit
specify --help, --sign, --verify, --import, --generate, --reset or --print
~ $ PIVIT_YK_SERIAL=1234 pivit
failed to open yubikey: no smart card found with serial number 1234
~ $ PIVIT_YK_SERIAL=10180478 pivit
specify --help, --sign, --verify, --import, --generate, --reset or --print
~ $ PIVIT_YK_SERIAL=asdf pivit
failed to open yubikey: invalid serial number format: strconv.ParseUint: parsing "asdf": invalid syntax
```

No YubiKeys:
```
~ $ pivit
failed to open yubikey: no smart card found
~ $ PIVIT_YK_SERIAL=asdf pivit
failed to open yubikey: no smart card found
```

Multiple yubikeys:
```
~ $ pivit
failed to open yubikey: multiple smart cards found but no serial specified
~ $ PIVIT_YK_SERIAL=10180478 pivit --print
f605a5b5f56cf0d622334b8d84c2eebaf4ffe2a7
-----BEGIN CERTIFICATE-----
...
~ $ PIVIT_YK_SERIAL=13077792 pivit --print
b59aff995edf77effa418ecfae23efa1445791e1
-----BEGIN CERTIFICATE-----
...
~ $ PIVIT_YK_SERIAL=1234 pivit
failed to open yubikey: no smart card found with serial number 1234
```