### PR TITLE
feat: add `--valid-days` flag for certificate validity

### DIFF
--- a/cmd/pivit/main.go
+++ b/cmd/pivit/main.go
@@ -34,6 +34,8 @@ func runCommand() error {
 	localUserOpt := getopt.StringLong("local-user", 'u', "", "use USER-ID to sign", "USER-ID")
 	detachSignFlag := getopt.BoolLong("detach-sign", 'b', "make a detached signature")
 	armorFlag := getopt.BoolLong("armor", 'a', "create ascii armored output")
+	validDaysOpt := getopt.IntLong("valid-days", 0, 0, "validity period in days for self-signed certificates (default 730)", "days")
+
 	statusFdOpt := getopt.IntLong("status-fd", 0, -1, "write special status strings to the file descriptor n.", "n")
 	firstOpt := getopt.BoolLong("first-pem", 0, "imports the first PEM block found when importing, ignoring the rest of the imported file")
 	tsaOpt := getopt.StringLong("timestamp-authority", 't', "", "URL of RFC3161 timestamp authority to use for timestamping", "url")
@@ -255,6 +257,7 @@ func runCommand() error {
 			Slot:                  pivit.GetSlot(*slot),
 			Prompt:                os.Stdin,
 			Pin:                   pin,
+			ValidityDays:          *validDaysOpt,
 		}
 		if generateCsr {
 			fmt.Println("Touch Yubikey now to sign your CSR...")

--- a/cmd/pivit/main.go
+++ b/cmd/pivit/main.go
@@ -34,7 +34,7 @@ func runCommand() error {
 	localUserOpt := getopt.StringLong("local-user", 'u', "", "use USER-ID to sign", "USER-ID")
 	detachSignFlag := getopt.BoolLong("detach-sign", 'b', "make a detached signature")
 	armorFlag := getopt.BoolLong("armor", 'a', "create ascii armored output")
-	validDaysOpt := getopt.IntLong("valid-days", 0, 0, "validity period in days for self-signed certificates (default 730)", "days")
+	validDaysOpt := getopt.IntLong("valid-days", 0, 0, "validity period in days for self-signed certificates (only when > 0)", "days")
 
 	statusFdOpt := getopt.IntLong("status-fd", 0, -1, "write special status strings to the file descriptor n.", "n")
 	firstOpt := getopt.BoolLong("first-pem", 0, "imports the first PEM block found when importing, ignoring the rest of the imported file")

--- a/pkg/pivit/generate.go
+++ b/pkg/pivit/generate.go
@@ -41,6 +41,9 @@ type GenerateCertificateOpts struct {
 	Prompt io.ReadCloser
 	// Pin to access the Yubikey
 	Pin string
+	// ValidityDays specifies the validity period (NotAfter - NotBefore) in days
+	// for self-signed certificates. If zero or negative, a default is used.
+	ValidityDays int
 }
 
 // CertificateParameters specifies the information encoded in the certificate
@@ -139,7 +142,7 @@ func GenerateCertificate(yk Pivit, opts *GenerateCertificateOpts) (*GenerateCert
 	})
 
 	if opts.SelfSign {
-		certificate, err := selfCertificate(deviceSerialNumber, publicKey, privateKey, opts.CertificateParameters)
+		certificate, err := selfCertificate(deviceSerialNumber, publicKey, privateKey, opts.CertificateParameters, opts.ValidityDays)
 		if err != nil {
 			return nil, err
 		}
@@ -179,7 +182,7 @@ func randomSerial() (*big.Int, error) {
 	return n, err
 }
 
-func selfCertificate(serialNumber string, publicKey crypto.PublicKey, privateKey crypto.PrivateKey, params CertificateParameters) (*x509.Certificate, error) {
+func selfCertificate(serialNumber string, publicKey crypto.PublicKey, privateKey crypto.PrivateKey, params CertificateParameters, validityDays int) (*x509.Certificate, error) {
 	subject := pkix.Name{
 		Organization:       params.SubjectOrganization,
 		OrganizationalUnit: params.SubjectOrganizationUnit,
@@ -202,8 +205,11 @@ func selfCertificate(serialNumber string, publicKey crypto.PublicKey, privateKey
 	// Set sane validity so signatures verify cleanly under time checks.
 	// Allow a small negative skew to tolerate local clock drift.
 	notBefore := time.Now().Add(-5 * time.Minute)
-	// Default validity window: 2 years (adjustable later via CLI if needed).
-	notAfter := notBefore.AddDate(2, 0, 0)
+	// Determine validity window: default to 2 years if not provided
+	if validityDays <= 0 {
+		validityDays = 730
+	}
+	notAfter := notBefore.AddDate(0, 0, validityDays)
 
 	cert := &x509.Certificate{
 		Subject:         subject,

--- a/pkg/pivit/generate.go
+++ b/pkg/pivit/generate.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/go-piv/piv-go/v2/piv"
 	"github.com/pkg/errors"
@@ -198,9 +199,17 @@ func selfCertificate(serialNumber string, publicKey crypto.PublicKey, privateKey
 		params.CertificateEmailAddresses = append(params.CertificateEmailAddresses, params.SubjectEmailAddress)
 	}
 
+	// Set sane validity so signatures verify cleanly under time checks.
+	// Allow a small negative skew to tolerate local clock drift.
+	notBefore := time.Now().Add(-5 * time.Minute)
+	// Default validity window: 2 years (adjustable later via CLI if needed).
+	notAfter := notBefore.AddDate(2, 0, 0)
+
 	cert := &x509.Certificate{
 		Subject:         subject,
 		SerialNumber:    serial,
+		NotBefore:       notBefore,
+		NotAfter:        notAfter,
 		DNSNames:        params.CertificateDNSNames,
 		EmailAddresses:  params.CertificateEmailAddresses,
 		IPAddresses:     params.CertificateIPAddresses,

--- a/pkg/pivit/generate.go
+++ b/pkg/pivit/generate.go
@@ -42,7 +42,7 @@ type GenerateCertificateOpts struct {
 	// Pin to access the Yubikey
 	Pin string
 	// ValidityDays specifies the validity period (NotAfter - NotBefore) in days
-	// for self-signed certificates. If zero or negative, a default is used.
+	// for self-signed certificates. If zero or negative, no validity period is set (backwards compatible).
 	ValidityDays int
 }
 
@@ -202,20 +202,9 @@ func selfCertificate(serialNumber string, publicKey crypto.PublicKey, privateKey
 		params.CertificateEmailAddresses = append(params.CertificateEmailAddresses, params.SubjectEmailAddress)
 	}
 
-	// Set sane validity so signatures verify cleanly under time checks.
-	// Allow a small negative skew to tolerate local clock drift.
-	notBefore := time.Now().Add(-5 * time.Minute)
-	// Determine validity window: default to 2 years if not provided
-	if validityDays <= 0 {
-		validityDays = 730
-	}
-	notAfter := notBefore.AddDate(0, 0, validityDays)
-
 	cert := &x509.Certificate{
 		Subject:         subject,
 		SerialNumber:    serial,
-		NotBefore:       notBefore,
-		NotAfter:        notAfter,
 		DNSNames:        params.CertificateDNSNames,
 		EmailAddresses:  params.CertificateEmailAddresses,
 		IPAddresses:     params.CertificateIPAddresses,
@@ -223,6 +212,17 @@ func selfCertificate(serialNumber string, publicKey crypto.PublicKey, privateKey
 		KeyUsage:        x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:     extKeyUsage,
 		ExtraExtensions: []pkix.Extension{},
+	}
+
+	// Only set validity period if explicitly requested (validityDays > 0)
+	// This preserves backwards compatibility - original behavior had zero times
+	if validityDays > 0 {
+		// Set sane validity so signatures verify cleanly under time checks.
+		// Allow a small negative skew to tolerate local clock drift.
+		notBefore := time.Now().Add(-5 * time.Minute)
+		notAfter := notBefore.AddDate(0, 0, validityDays)
+		cert.NotBefore = notBefore
+		cert.NotAfter = notAfter
 	}
 
 	data, err := x509.CreateCertificate(rand.Reader, cert, cert, publicKey, privateKey)

--- a/pkg/pivit/generate_test.go
+++ b/pkg/pivit/generate_test.go
@@ -1,7 +1,10 @@
 package pivit
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"testing"
+	"time"
 
 	"github.com/go-piv/piv-go/v2/piv"
 	"github.com/stretchr/testify/assert"
@@ -107,4 +110,86 @@ func TestGenerateCertificate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerateCertificate_BackwardsCompatibility(t *testing.T) {
+	yk, err := testYubikey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	patchPivVerify(yk)
+	defer unpatchPinVerify()
+	defer func() {
+		_ = yk.Reset()
+	}()
+
+	// Test that when ValidityDays is 0 (default), we get the original behavior
+	// with zero times for NotBefore and NotAfter
+	opts := &GenerateCertificateOpts{
+		Algorithm:    piv.AlgorithmEC384,
+		SelfSign:     true,
+		AssumeYes:    true,
+		ValidityDays: 0, // Default value - should preserve original behavior
+		Slot:         piv.SlotCardAuthentication,
+		Pin:          piv.DefaultPIN,
+	}
+
+	result, err := GenerateCertificate(yk, opts)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+
+	// Parse the certificate and verify it has zero times (backwards compatible behavior)
+	block, _ := pem.Decode(result.Certificate)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	assert.NoError(t, err)
+	assert.True(t, cert.NotBefore.IsZero(), "NotBefore should be zero time for backwards compatibility")
+	assert.True(t, cert.NotAfter.IsZero(), "NotAfter should be zero time for backwards compatibility")
+}
+
+func TestGenerateCertificate_ValidityDays(t *testing.T) {
+	yk, err := testYubikey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	patchPivVerify(yk)
+	defer unpatchPinVerify()
+	defer func() {
+		_ = yk.Reset()
+	}()
+
+	// Test that when ValidityDays > 0, we get proper validity times
+	validityDays := 365
+	opts := &GenerateCertificateOpts{
+		Algorithm:    piv.AlgorithmEC384,
+		SelfSign:     true,
+		AssumeYes:    true,
+		ValidityDays: validityDays,
+		Slot:         piv.SlotCardAuthentication,
+		Pin:          piv.DefaultPIN,
+	}
+
+	before := time.Now()
+	result, err := GenerateCertificate(yk, opts)
+	after := time.Now()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+
+	// Parse the certificate and verify it has proper validity times
+	block, _ := pem.Decode(result.Certificate)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	assert.NoError(t, err)
+
+	// Verify NotBefore is set to roughly now (with 5 minute negative skew)
+	assert.False(t, cert.NotBefore.IsZero(), "NotBefore should not be zero when ValidityDays > 0")
+	assert.True(t, cert.NotBefore.Before(before), "NotBefore should be before test start (due to negative skew)")
+	assert.True(t, cert.NotBefore.After(before.Add(-10*time.Minute)), "NotBefore should be within 10 minutes of test start")
+
+	// Verify NotAfter is set to roughly ValidityDays from now
+	assert.False(t, cert.NotAfter.IsZero(), "NotAfter should not be zero when ValidityDays > 0")
+	expectedNotAfter := cert.NotBefore.AddDate(0, 0, validityDays)
+	assert.True(t, cert.NotAfter.Equal(expectedNotAfter), "NotAfter should be exactly ValidityDays after NotBefore")
+	assert.True(t, cert.NotAfter.After(after.AddDate(0, 0, validityDays-1)), "NotAfter should be roughly ValidityDays from now")
 }

--- a/pkg/pivit/pivit.go
+++ b/pkg/pivit/pivit.go
@@ -30,7 +30,6 @@ type Pivit interface {
 
 var _ Pivit = (*piv.YubiKey)(nil)
 
-
 // YubikeyHandle returns a handle to the connected piv.YubiKey.
 // It errors unless there is exactly one YubiKey connected.
 func YubikeyHandle() (*piv.YubiKey, error) {


### PR DESCRIPTION
## Summary
Adds a new `--valid-days` CLI flag to control the validity period of self-signed certificates

If omitted, pivit defaults to previous behavior for backwards compatibility

## Motivation

Previously, self-signed certificates generated by pivit had zero `NotBefore` and `NotAfter` times, which could cause issues with any tool that couldn't be set up toignore the validity

## Changes
- **New flag**: `--valid-days` (integer) - specify validity period in days for self-signed certificates
- **Default**: `0` (preserves existing zero-time behavior)
- **When > 0**: Sets proper `NotBefore`/`NotAfter` with 5-minute negative skew for clock drift
- **Backwards compatible**: Existing workflows unchanged, opt-in only

### More Change Details
- When `--valid-days > 0`: Sets proper `NotBefore` and `NotAfter` times with 5-minute negative skew for clock drift tolerance
- When `--valid-days = 0` (default): Preserves original behavior with zero times for backwards compatibility
- Only affects self-signed certificates (`--self-sign` flag)


## Testing
- `TestGenerateCertificate_BackwardsCompatibility()`: Verifies zero times when flag not used
- `TestGenerateCertificate_ValidityDays()`: Validates proper validity period setting

## Example

```bash
# Generate self-signed cert valid for 1 year
pivit --generate --self-sign --valid-days 365
# Generate self-signed cert valid for 30 days
pivit --generate --self-sign --valid-days 30
# Original behavior (zero times) - unchanged
pivit --generate --self-sign
```


